### PR TITLE
NRM-28 add timestamps to logging & run all tests in one script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
 /* eslint-disable consistent-return, no-console */
 'use strict';
 
-const winston = require('winston');
+const { createLogger, format, transports } = require('winston');
+const { combine, timestamp, json } = format;
 const { Consumer } = require('sqs-consumer');
 const SubmitCase = require('./models/i-casework');
 const GetCase = require('./models/i-casework-getcase');
 const config = require('./config');
-const transports = [
-  new winston.transports.Console({
-    level: 'info',
-    handleExceptions: true
-  })
-];
+const logger = createLogger({
+  format: combine(
+    timestamp(),
+    json()
+  ),
+  transports: [
+    new transports.Console({level: 'info',
+      handleExceptions: true
+    })]
+});
 let db;
 
 if (config.audit) {
   db = require('./db');
 }
-
-const logger = winston.createLogger({
-  transports,
-  format: winston.format.json()
-});
 
 const logError = (id, errorType, err) => {
   logger.log('error', id);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon -r dotenv/config index.js",
+    "test": "yarn test:lint && yarn test:snyk",
     "test:lint": "eslint . --config ./node_modules/eslint-config-hof/default.js",
     "test:snyk": "snyk config set api=SNYK_TOKEN && snyk test"
   },


### PR DESCRIPTION
## What

* Add timestamps to logging 
* Run all tests in one command

## Why 

Because it will be helpful to determine when an issue occurred to diagnose a problem

## Tested

Tested on the ms-branch environment and it works
``{"level":"info","message":"Resolver is listening for messages from: https://sqs.eu-west-2.amazonaws.com/449472082214/sas-ms-branch-sqs","timestamp":"2021-11-24T21:31:37.238Z"}
{"caseID":"4898750","level":"info","message":"Casework submission successful","timestamp":"2021-11-24T21:32:44.833Z"}``